### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v31
+        uses: tj-actions/changed-files@v35.4.1
 
       - name: Check if changelog was touched
         run: |
@@ -39,10 +39,10 @@ jobs:
       matrix:
         node-version: [14.x, 16.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -25,14 +25,14 @@ jobs:
   release-it:
     runs-on: ubuntu-latest
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: tibdex/github-app-token@v1.7.0
         id: generate-token
         with:
           app_id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private_key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           # we need everything so release-it can compare the current version with the latest tag

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -8,7 +8,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: neolution-ch/action-release-notifier@v1
+      - uses: neolution-ch/action-release-notifier@v1.1.0
         with:
           slack-token: ${{ secrets.SLACK_RELEASE_NOTIFIER_TOKEN }}
           slack-channel-ids: "CQRJECWGY"

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -8,10 +8,10 @@ jobs:
   build-storybook:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: 16
           cache: "yarn"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[tj-actions/changed-files](https://github.com/tj-actions/changed-files)** published a new release **[v35.4.1](https://github.com/tj-actions/changed-files/releases/tag/v35.4.1)** on 2023-01-11T21:18:38Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.6.0](https://github.com/actions/setup-node/releases/tag/v3.6.0)** on 2023-01-05T14:09:37Z
* **[tibdex/github-app-token](https://github.com/tibdex/github-app-token)** published a new release **[v1.7.0](https://github.com/tibdex/github-app-token/releases/tag/v1.7.0)** on 2022-10-16T17:10:00Z
* **[neolution-ch/action-release-notifier](https://github.com/neolution-ch/action-release-notifier)** published a new release **[v1.1.0](https://github.com/neolution-ch/action-release-notifier/releases/tag/v1.1.0)** on 2022-10-27T09:59:34Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
