### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v31
+        uses: tj-actions/changed-files@v35.4.1
 
       - name: Check if changelog was touched
         run: |
@@ -39,7 +39,7 @@ jobs:
       matrix:
         node-version: [14.x, 16.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -8,7 +8,7 @@ jobs:
   build-storybook:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
 
       - name: Use Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
* **[tj-actions/changed-files](https://github.com/tj-actions/changed-files)** published a new release **[v35.4.1](https://github.com/tj-actions/changed-files/releases/tag/v35.4.1)** on 2023-01-11T21:18:38Z
