### PR TITLE
Feature/fix inputs addons spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed checkbox/radio label spacing due to `addonLeft` and `addonRight` props
+
 ## [1.1.1] - 2023-07-20
 
 ### Fixed

--- a/src/lib/FormGroupLayout.tsx
+++ b/src/lib/FormGroupLayout.tsx
@@ -36,18 +36,18 @@ const FormGroupLayout = <T extends FieldValues>(props: FormGroupLayoutProps<T>) 
       <FormFeedback>{errorMessage}</FormFeedback>
     </>
   ) : (
-    <FormGroup switch={switchLayout ? true : undefined} check={checkboxLayout ? true : undefined}>
+    <FormGroup switch={switchLayout ? true : undefined} check={checkboxLayout ? true : undefined} >
       <FormGroupLayoutLabel<T> label={label} fieldName={name} fieldId={id} tooltip={labelToolTip} layout={layout} />
-      <InputGroup
-        style={{
-          flexWrap: "nowrap",
-        }}
-        className={fieldError ? "is-invalid" : undefined}
-      >
-        {addonLeft}
-        {children}
-        {addonRight}
-      </InputGroup>
+        {switchLayout || checkboxLayout ? children : <InputGroup
+            style={{
+                flexWrap: "nowrap", alignItems: "center",
+            }}
+            className={fieldError ? "is-invalid" : undefined}
+        >
+            {addonLeft}
+            {children}
+            {addonRight}
+        </InputGroup>}
       <FormFeedback>{errorMessage}</FormFeedback>
       {helpText && <FormText>{helpText}</FormText>}
     </FormGroup>

--- a/src/lib/FormGroupLayout.tsx
+++ b/src/lib/FormGroupLayout.tsx
@@ -36,18 +36,23 @@ const FormGroupLayout = <T extends FieldValues>(props: FormGroupLayoutProps<T>) 
       <FormFeedback>{errorMessage}</FormFeedback>
     </>
   ) : (
-    <FormGroup switch={switchLayout ? true : undefined} check={checkboxLayout ? true : undefined} >
+    <FormGroup switch={switchLayout ? true : undefined} check={checkboxLayout ? true : undefined}>
       <FormGroupLayoutLabel<T> label={label} fieldName={name} fieldId={id} tooltip={labelToolTip} layout={layout} />
-        {switchLayout || checkboxLayout ? children : <InputGroup
-            style={{
-                flexWrap: "nowrap", alignItems: "center",
-            }}
-            className={fieldError ? "is-invalid" : undefined}
+      {switchLayout || checkboxLayout ? (
+        children
+      ) : (
+        <InputGroup
+          style={{
+            flexWrap: "nowrap",
+            alignItems: "center",
+          }}
+          className={fieldError ? "is-invalid" : undefined}
         >
-            {addonLeft}
-            {children}
-            {addonRight}
-        </InputGroup>}
+          {addonLeft}
+          {children}
+          {addonRight}
+        </InputGroup>
+      )}
       <FormFeedback>{errorMessage}</FormFeedback>
       {helpText && <FormText>{helpText}</FormText>}
     </FormGroup>


### PR DESCRIPTION
Fixed checkbox/radio label spacing due to `addonLeft` and `addonRight` props
