### PR TITLE
Add step to input types number and range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `step` property to `Input` component
+
 ## [2.3.0] - 2023-12-12
 
 ### Added

--- a/cypress/cypress/component/Input/BasicInputField.cy.tsx
+++ b/cypress/cypress/component/Input/BasicInputField.cy.tsx
@@ -58,8 +58,9 @@ describe("Input.cy.tsx", () => {
       [name]: yup.number(),
     });
 
+    const step = faker.datatype.number({ min: 1 });
     const randomNumber = faker.datatype.number();
-    const step = 2;
+    const expectedResult = randomNumber + step - (randomNumber % step);
 
     cy.mount(
       <Form onSubmit={cy.spy().as("onSubmitSpy")} resolver={yupResolver(schema)}>
@@ -71,9 +72,10 @@ describe("Input.cy.tsx", () => {
 
     cy.contains("label", name).click().type(randomNumber.toString());
     cy.get(`input[id=${name}]`).should("have.attr", "step", step.toString());
+    cy.get(`input[id=${name}]`).click({ force: true }).type("{uparrow}");
     cy.get("input[type=submit]").click({ force: true });
 
-    cy.get("@onSubmitSpy").should("be.calledOnceWith", { [name]: randomNumber });
+    cy.get("@onSubmitSpy").should("be.calledOnceWith", { [name]: expectedResult });
   });
 
   it("help text gets displayed", () => {
@@ -287,29 +289,6 @@ describe("Input.cy.tsx", () => {
     );
 
     cy.get(`input[id=${name}]`).setSliderValue(selectedValue);
-    cy.get("input[type=submit]").click({ force: true });
-    cy.get("@onSubmitSpy").should("be.calledOnceWith", { [name]: selectedValue });
-  });
-
-  it("range input works with step", () => {
-    const name = faker.random.alpha(10);
-    const schema = yup.object().shape({
-      [name]: yup.number(),
-    });
-
-    const [min, selectedValue, max] = faker.helpers.uniqueArray(faker.datatype.number, 3).sort((a, b) => a - b);
-    const step = 2;
-
-    cy.mount(
-      <Form onSubmit={cy.spy().as("onSubmitSpy")} resolver={yupResolver(schema)}>
-        <Input type="range" name={name} label={name} rangeMin={min} rangeMax={max} step={step} />
-
-        <input type={"submit"} />
-      </Form>,
-    );
-
-    cy.get(`input[id=${name}]`).setSliderValue(selectedValue);
-    cy.get(`input[id=${name}]`).should("have.attr", "step", step.toString());
     cy.get("input[type=submit]").click({ force: true });
     cy.get("@onSubmitSpy").should("be.calledOnceWith", { [name]: selectedValue });
   });

--- a/cypress/cypress/component/Input/BasicInputField.cy.tsx
+++ b/cypress/cypress/component/Input/BasicInputField.cy.tsx
@@ -52,7 +52,7 @@ describe("Input.cy.tsx", () => {
     cy.get("@onSubmitSpy").should("be.calledOnceWith", { [name]: randomNumber });
   });
 
-  it("number accepts step", () => {
+  it("number input correctly increase value according to step", () => {
     const name = faker.random.alpha(10);
     const schema = yup.object().shape({
       [name]: yup.number(),

--- a/cypress/cypress/component/Input/BasicInputField.cy.tsx
+++ b/cypress/cypress/component/Input/BasicInputField.cy.tsx
@@ -52,6 +52,30 @@ describe("Input.cy.tsx", () => {
     cy.get("@onSubmitSpy").should("be.calledOnceWith", { [name]: randomNumber });
   });
 
+  it("number accepts step", () => {
+    const name = faker.random.alpha(10);
+    const schema = yup.object().shape({
+      [name]: yup.number(),
+    });
+
+    const randomNumber = faker.datatype.number();
+    const step = 2;
+
+    cy.mount(
+      <Form onSubmit={cy.spy().as("onSubmitSpy")} resolver={yupResolver(schema)}>
+        <Input type="number" name={name} label={name} step={step} />
+
+        <input type={"submit"} />
+      </Form>,
+    );
+
+    cy.contains("label", name).click().type(randomNumber.toString());
+    cy.get(`input[id=${name}]`).should("have.attr", "step", step.toString());
+    cy.get("input[type=submit]").click({ force: true });
+
+    cy.get("@onSubmitSpy").should("be.calledOnceWith", { [name]: randomNumber });
+  });
+
   it("help text gets displayed", () => {
     const name = faker.random.alpha(10);
     const schema = yup.object().shape({
@@ -263,6 +287,29 @@ describe("Input.cy.tsx", () => {
     );
 
     cy.get(`input[id=${name}]`).setSliderValue(selectedValue);
+    cy.get("input[type=submit]").click({ force: true });
+    cy.get("@onSubmitSpy").should("be.calledOnceWith", { [name]: selectedValue });
+  });
+
+  it("range input works with step", () => {
+    const name = faker.random.alpha(10);
+    const schema = yup.object().shape({
+      [name]: yup.number(),
+    });
+
+    const [min, selectedValue, max] = faker.helpers.uniqueArray(faker.datatype.number, 3).sort((a, b) => a - b);
+    const step = 2;
+
+    cy.mount(
+      <Form onSubmit={cy.spy().as("onSubmitSpy")} resolver={yupResolver(schema)}>
+        <Input type="range" name={name} label={name} rangeMin={min} rangeMax={max} step={step} />
+
+        <input type={"submit"} />
+      </Form>,
+    );
+
+    cy.get(`input[id=${name}]`).setSliderValue(selectedValue);
+    cy.get(`input[id=${name}]`).should("have.attr", "step", step.toString());
     cy.get("input[type=submit]").click({ force: true });
     cy.get("@onSubmitSpy").should("be.calledOnceWith", { [name]: selectedValue });
   });

--- a/src/lib/Input.tsx
+++ b/src/lib/Input.tsx
@@ -21,10 +21,11 @@ interface InputProps<T extends FieldValues> extends CommonInputProps<T> {
   textAreaRows?: number;
   plainText?: boolean;
   placeholder?: string;
+  step?: number;
 }
 
 const Input = <T extends FieldValues>(props: InputProps<T>) => {
-  const { type, options, addonLeft, name, addonRight, rangeMin, rangeMax, textAreaRows, multiple, id, value, disabled } = props;
+  const { type, options, addonLeft, name, addonRight, rangeMin, rangeMax, textAreaRows, multiple, id, value, disabled, step } = props;
 
   if (type === "radio" && !options) {
     throw new Error("options must be provided for radio inputs");
@@ -49,6 +50,9 @@ const Input = <T extends FieldValues>(props: InputProps<T>) => {
   }
   if (options && options.filter((option) => option.value === undefined).length > 1) {
     throw new Error("options can only contain one undefined value");
+  }
+  if (step && type !== "number" && type !== "range") {
+    throw new Error("step can only be used with number or range inputs");
   }
 
   const formGroupLayout = (() => {

--- a/src/lib/InputInternal.tsx
+++ b/src/lib/InputInternal.tsx
@@ -22,6 +22,7 @@ const InputInternal = <T extends FieldValues>(props: InputProps<T>) => {
     textAreaRows,
     plainText,
     placeholder,
+    step,
     markAllOnFocus,
     className,
     style,
@@ -56,6 +57,7 @@ const InputInternal = <T extends FieldValues>(props: InputProps<T>) => {
         plaintext={plainText}
         style={plainText ? { color: "black", marginLeft: 10, ...style } : { ...style }}
         placeholder={placeholder}
+        step={step}
         {...rest}
         {...(value ? { value } : {})}
         onBlur={(e) => {


### PR DESCRIPTION
Input component was missing the step functionality for input of type "number" and "range", which we now require for some pages in AdvisorySuite. This implementation is trivial because step is already a browser supported functionality, we are just making sure only input of the mentioned types can pass it as prop.