### PR TITLE
add "autoComplete" prop to Input component

### DIFF
--- a/src/lib/Input.tsx
+++ b/src/lib/Input.tsx
@@ -23,6 +23,7 @@ interface InputProps<T extends FieldValues> extends CommonInputProps<T> {
   plainText?: boolean;
   placeholder?: string;
   step?: number;
+  autoComplete?: string;
   innerRef?: MutableRefObject<HTMLInputElement | HTMLTextAreaElement | null>;
 }
 

--- a/src/lib/InputInternal.tsx
+++ b/src/lib/InputInternal.tsx
@@ -29,6 +29,7 @@ const InputInternal = <T extends FieldValues>(props: InputProps<T>) => {
     innerRef,
     minLength,
     maxLength,
+    autoComplete,
   } = props;
   const { name, id } = useSafeNameId(props.name, props.id);
   const focusHandler = useMarkOnFocusHandler(markAllOnFocus);
@@ -68,6 +69,7 @@ const InputInternal = <T extends FieldValues>(props: InputProps<T>) => {
         style={plainText ? { color: "black", marginLeft: 10, ...style } : { ...style }}
         placeholder={placeholder}
         step={step}
+        autoComplete={autoComplete}
         {...rest}
         {...(value ? { value } : {})}
         onBlur={(e) => {


### PR DESCRIPTION
**Added** `autoComplete` **Prop to** `Input` **Component**

This PR introduces a new `autoComplete` prop to the `Input` component, allowing users to enable or disable the browser's autocomplete functionality for the input field.

- No breaking changes introduced.
- Compatible with existing usage of the `Input` component.